### PR TITLE
fix(style): make MobileHeader display correctly

### DIFF
--- a/src/components/MobileHeader.vue
+++ b/src/components/MobileHeader.vue
@@ -31,6 +31,7 @@ export default {
   top: 0;
   left: 0;
   right: 0;
+  z-index: 3;
 }
 
 .SiteTitle {


### PR DESCRIPTION
The value of z-index should be at least 3, otherwise it will be as shown below:

![img](https://user-images.githubusercontent.com/14146560/45965290-ac978180-c05a-11e8-99e2-b35c3db55bba.jpeg)



